### PR TITLE
Feature/remove old spam users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'country_select'
 gem "devise", "~> 4.7"
 gem "devise_invitable", "~> 2"
 gem "devise-i18n"
+gem 'discard', '~> 1.2'
 gem 'friendly_id', '~> 5.3.0' # 5.4.0 has a breaking change! https://github.com/norman/friendly_id/pull/787
 gem 'geocoder'
 gem 'groupdate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,8 @@ GEM
     devise_invitable (2.0.1)
       actionmailer (>= 5.0)
       devise (>= 4.6)
+    discard (1.3.0)
+      activerecord (>= 4.2, < 8)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.8.1)
@@ -465,6 +467,7 @@ DEPENDENCIES
   devise (~> 4.7)
   devise-i18n
   devise_invitable (~> 2)
+  discard (~> 1.2)
   dotenv-rails
   faker (~> 2.19)
   friendly_id (~> 5.3.0)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,7 +18,7 @@ class UsersController < ApplicationController
   def index
     @q = User
       .includes(avatar_attachment: :blob)
-      .ransack(params[:q])
+      .ransack(params[:q], {auth_object: :api})
     @users = @q.result(distinct: true).page(params[:page])
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,9 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
+  include Discard::Model
+  default_scope { kept }
+
   devise :database_authenticatable, :registerable,
          :invitable, :confirmable,
          :recoverable, :rememberable, :validatable,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,7 +31,11 @@ class User < ApplicationRecord
   # The /users.json endpoint is using Ransack.
   # Only allow to search for name, not email.
   def self.ransackable_attributes(auth_object = nil)
-    super & %w(first_name last_name slug)
+    if auth_object == :api
+      super & %w(first_name last_name slug)
+    else
+      super
+    end
   end
 
   def to_s

--- a/db/migrate/20240110181520_add_discarded_at_to_users.rb
+++ b/db/migrate/20240110181520_add_discarded_at_to_users.rb
@@ -1,0 +1,6 @@
+class AddDiscardedAtToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :discarded_at, :datetime
+    add_index :users, :discarded_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_12_01_122728) do
+ActiveRecord::Schema.define(version: 2024_01_10_181520) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -433,6 +433,8 @@ ActiveRecord::Schema.define(version: 2023_12_01_122728) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
+    t.datetime "discarded_at"
+    t.index ["discarded_at"], name: "index_users_on_discarded_at"
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invitations_count"], name: "index_users_on_invitations_count"
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"

--- a/lib/tasks/makeworks.rake
+++ b/lib/tasks/makeworks.rake
@@ -9,4 +9,22 @@ namespace :makeworks do
       end
     end
   end
+
+  desc "Delete spam users from CSV file"
+  task delete_spam_users: :environment do
+    require 'csv'
+    path = ENV.fetch("SPAM_USERS_CSV")
+    CSV.foreach(path,  encoding: "bom|utf-8", liberal_parsing: true, col_sep: ";") do |line|
+        if line[1] == "TRUE"
+          line[0].split(";").each do |email|
+            user = User.find_by(email: email.strip)
+            if user
+              user.discard!
+            else
+              print "WARN: user not found  for email: #{email.strip}"
+            end
+          end
+        end
+    end
+  end
 end


### PR DESCRIPTION
Various things needed to remove all the old spam users accounts.

- Fix the 500 error on the user admin page
- Add the `discard` gem for soft deletes
- Add a rake task to read the CSV file and discard spam users