### PR TITLE
Add region aliases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,22 @@
 FROM ruby:2.7.6
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs postgresql-client
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev postgresql-client software-properties-common
+
+RUN curl -sL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
+
+RUN add-apt-repository "deb https://deb.nodesource.com/node_14.x $(lsb_release -sc) main"
+
+RUN apt-get update -qq && apt-get install -y nodejs
+
+RUN npm install -g yarn
+
 RUN mkdir /app
+
 WORKDIR /app
-copy .ruby-version /app/.ruby-version
+
+COPY .ruby-version /app/.ruby-version
 COPY Gemfile /app/Gemfile
 COPY Gemfile.lock /app/Gemfile.lock
+
 RUN bundle install
+
 CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/app/admin/regions.rb
+++ b/app/admin/regions.rb
@@ -4,7 +4,7 @@ ActiveAdmin.register Region do
   #
   # Uncomment all parameters which should be permitted for assignment
   #
-  permit_params :m_id, :name, :can_signup, :is_public, :logo, :slug, :lat, :lng
+  permit_params :m_id, :name, :can_signup, :is_public, :logo, :slug, :lat, :lng, aliases_attributes: [:alias, :id, :_destroy]
   #
   # or
   #
@@ -16,4 +16,22 @@ ActiveAdmin.register Region do
 
   scope :all
   scope :is_public
+
+
+  show do
+    default_main_content
+    h3 "Aliases:"
+    table_for region.aliases do |region_alias|
+      column :alias
+    end
+  end
+
+  form do |f|
+    f.semantic_errors # shows errors on :base
+    f.inputs          # builds an input field for every attribute
+    f.has_many :aliases, new_record: "New alias", remove_record: "Remove alias", allow_destroy: true do |alias_f|
+      alias_f.input :alias, as: :string
+    end
+    f.actions         # adds the 'Submit' and 'Cancel' buttons
+  end
 end

--- a/app/javascript/controllers/select2_controller.js
+++ b/app/javascript/controllers/select2_controller.js
@@ -1,8 +1,39 @@
 import { Controller } from "stimulus";
-
 export default class extends Controller {
   connect() {
-    $(this.element).select2({ width: "100%" });
+    let originalMatcher = $.fn.select2.defaults.defaults.matcher;
+    // This is deeply unsatisfactory, but needed in order to properly normalise
+    // the additional aliases when matching, see:
+    // https://stackoverflow.com/questions/35557486/select2-custom-matcher-but-keep-stripdiacritics
+    let stripDiacritics = undefined;
+    $.fn.select2.amd.require(['select2/diacritics'], function (DIACRITICS) {
+      stripDiacritics = (text) => {
+        function match(a) {
+          return DIACRITICS[a] || a;
+        }
+        return text.replace(/[^\u0000-\u007E]/g, match);
+      };
+    });
+    let aliasMatcher = (params, data) => {
+      var alias = data.element.getAttribute("data-aliases");
+
+      if(alias) {
+        var aliasNormalised = stripDiacritics(alias).toUpperCase();
+        var term = stripDiacritics(params.term).toUpperCase();
+
+        // Check if the text contains the term
+        if (aliasNormalised.indexOf(term) > -1) {
+          return data;
+        }
+      }
+      return null;
+    };
+
+    let combinedMatcher = (params, data) => {
+      return originalMatcher(params, data) || aliasMatcher(params, data);
+    };
+
+    $(this.element).select2({ width: "100%", matcher: combinedMatcher});
     $(this.element).on("select2:select", function () {
       let event = new Event("change", { bubbles: true }); // fire a native event
       this.dispatchEvent(event);

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -5,6 +5,8 @@ class Region < ApplicationRecord
   has_many :company_organization, dependent: :destroy
   has_many :companies, through: :company_organization
 
+  has_many :aliases, class_name: "RegionAlias", inverse_of: :region
+
   default_scope { order(name: :asc) }
   scope :is_public, -> { where(is_public: true) }
 
@@ -17,6 +19,8 @@ class Region < ApplicationRecord
   has_rich_text :about_text
   has_rich_text :partner_text
   has_many_attached :partner_logos
+
+  accepts_nested_attributes_for :aliases, allow_destroy: true
 
   def champions
     UserRegion.where(region: self, is_champion: true)

--- a/app/models/region_alias.rb
+++ b/app/models/region_alias.rb
@@ -1,0 +1,4 @@
+class RegionAlias < ApplicationRecord
+  belongs_to :region
+  validates :alias, presence: true
+end

--- a/app/views/companies/_table_filters.html.erb
+++ b/app/views/companies/_table_filters.html.erb
@@ -26,7 +26,7 @@
       <div class="mt-2">
         <label><%= t('shared.regions') %></label>
         <%= f.select :regions_id_in,
-          Region.where(is_public: true).pluck(:name, :id),
+          Region.includes(:aliases).where(is_public: true).map { |r| [r.name, r.id, {"data-aliases": r.aliases.map(&:alias).join(",")}]},
           { include_blank: t('companies.filters.all_regions') },
           { class: '', multiple: true, 'data-controller': 'select2',
            data: { action: "change->companies-search-form#search" } }

--- a/db/migrate/20240423112623_create_region_aliases.rb
+++ b/db/migrate/20240423112623_create_region_aliases.rb
@@ -1,0 +1,10 @@
+class CreateRegionAliases < ActiveRecord::Migration[7.0]
+  def change
+    create_table :region_aliases do |t|
+      t.integer :region_id
+      t.text :alias
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_22_070540) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_23_112623) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -362,6 +362,13 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_22_070540) do
   create_table "production_accesses", force: :cascade do |t|
     t.string "name"
     t.integer "position"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "region_aliases", force: :cascade do |t|
+    t.integer "region_id"
+    t.text "alias"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/lib/tasks/makeworks.rake
+++ b/lib/tasks/makeworks.rake
@@ -27,4 +27,41 @@ namespace :makeworks do
         end
     end
   end
+
+  DEFAULT_ALIASES = {
+    "Make Works UAE": [
+      "Make Works United Arab Emirates",
+    ],
+    "Make Works Vienna": [
+      "Make Works Wien"
+    ],
+    "Make Works Catalonia": [
+      "Make Works Cataluña",
+      "Make Works Catalunya"
+    ],
+    "Make Works Iceland": [
+      "Make Works Ísland"
+    ],
+    "Make Works Kingston NY": [
+      "Make Works Kingston New York"
+    ],
+    "Make Works Sweden": [
+      "Make Works Sverige"
+    ]
+  }
+
+  desc "Add some common region aliases"
+  task create_region_aliases: :environment do
+    DEFAULT_ALIASES.each do |region_name, aliases|
+      region = Region.find_by(name: region_name)
+      unless region
+        puts "Region with name '#{region_name}' not found, skipping..."
+        next
+      end
+
+      aliases.each do |alias_name|
+        region.aliases.find_or_create_by(alias: alias_name)
+      end
+    end
+  end
 end


### PR DESCRIPTION
These are not displayed, but are used as matching text in the search
form dropdown, so one could write "Make Works United Arab Emirates", or
some substring of it, and see "Make Works UAE" selected. Aliases are
editable through the regions admin page, and a rake task has been
provided `makeworks:create_region_aliases` to create appropriate ones
for existing regions (eg local language names where they are different,
plus widely known abbreviations)